### PR TITLE
feat: adding new token amount to options

### DIFF
--- a/quiz_agent/src/bot/handlers.py
+++ b/quiz_agent/src/bot/handlers.py
@@ -1923,6 +1923,10 @@ async def handle_token_selection(update, context):
                         InlineKeyboardButton("1000", callback_data="token_amount_1000"),
                     ],
                     [
+                        InlineKeyboardButton("5000", callback_data="token_amount_5000"),
+                        InlineKeyboardButton("10000", callback_data="token_amount_10000"),
+                    ],
+                    [
                         InlineKeyboardButton(
                             "Custom amount", callback_data="token_amount_custom"
                         ),


### PR DESCRIPTION
This pull request adds two new token amount options to the token selection keyboard in the bot interface, giving users more flexibility when choosing token amounts.

**Enhancements to token selection options:**

* Added "5000" and "10000" token amount buttons to the inline keyboard in the `handle_token_selection` handler (`quiz_agent/src/bot/handlers.py`).